### PR TITLE
Add underline to `:hover` for `.card-title a`

### DIFF
--- a/css/02-typography.css
+++ b/css/02-typography.css
@@ -199,12 +199,13 @@ main .card-categories {
 }
 
 main .card-title a {
-	border: none;
-	transition: color .3s ease;
+	border-color: transparent;
+	transition: all .3s ease;
 }
 
 main .card-title a:hover {
 	color: #ca1237;
+	border-color: currentColor;
 }
 
 .card-byline-date,

--- a/style.css
+++ b/style.css
@@ -612,12 +612,13 @@ main .card-categories {
 }
 
 main .card-title a {
-	border: none;
-	transition: color .3s ease;
+	border-color: transparent;
+	transition: all .3s ease;
 }
 
 main .card-title a:hover {
 	color: #ca1237;
+	border-color: currentColor;
 }
 
 .card-byline-date,


### PR DESCRIPTION
- Remove doubt about `.card-title a` links passing WCAG 2.0 AA with only having a color change on `:hover` by adding `text-decoration` on `:hover`.