### PR TITLE
[PR] Cleanup Markup

### DIFF
--- a/category.php
+++ b/category.php
@@ -1,7 +1,7 @@
 <?php
 
 get_header();
-global $is_top_feature;
+global $is_top_feature, $is_river;
 ?>
 	<main id="wsuwp-main" class="spine-category-index">
 
@@ -24,6 +24,7 @@ global $is_top_feature;
 						<?php
 						$skip_post_id[] = get_post()->ID;
 						$is_top_feature = true;
+						$is_river = false;
 						get_template_part( 'parts/card-content' );
 						?>
 
@@ -38,6 +39,7 @@ global $is_top_feature;
 		}
 
 		$is_top_feature = false;
+		$is_river = false;
 		$archive_query = new WP_Query( array(
 			'posts_per_page' => 20, // Start with a high number until pagination.
 			'category_name' => get_query_var( 'category_name' ),
@@ -52,6 +54,7 @@ global $is_top_feature;
 
 				// 4 posts are output in the secondary section.
 				if ( 0 === $output_post_count ) {
+					$is_river = false;
 					?>
 					<section class="row single gutter pad-top top-four">
 						<div class="column one">
@@ -61,6 +64,7 @@ global $is_top_feature;
 
 				// Remaining posts are output as a river.
 				if ( 4 === $output_post_count ) {
+					$is_river = true;
 					?>
 							</div>
 						</div>

--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -205,11 +205,6 @@ main figure > a {
 	margin-bottom: 1rem;
 }
 
-main .cat-sec .card-categories,
-.category main .card-categories {
-	display: none;
-}
-
 .card-title {
 	margin-bottom: .5rem;
 }
@@ -232,7 +227,6 @@ main .cat-sec .card-categories,
 
 .deck--featured .card:first-child .card-title,
 .deck--featured .card:first-child .card-categories,
-.deck--featured .card:first-child .card-byline,
 .deck--featured .card:first-child .card-excerpt {
 	display: block;
 	padding-right: 1rem;
@@ -255,7 +249,6 @@ main .deck--featured .card:first-child .card-title a:after {
 
 	.deck--featured .card:first-child .card-title,
 	.deck--featured .card:first-child .card-categories,
-	.deck--featured .card:first-child .card-byline,
 	.deck--featured .card:first-child .card-excerpt,
 	.deck--featured .card:first-child .card-image {
 		padding-right: 0;

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -172,9 +172,7 @@ function wsuwp_json_output( $content, $data, $atts ) {
 					<header class="card-title">
 						<a href="<?php echo esc_url( $content->link ); ?>"><?php echo esc_html( $content->title ); ?></a>
 					</header>
-					<span class="card-byline">
-						<span class="card-date"><?php echo esc_html( date( $atts['date_format'], strtotime( $content->date ) ) ); ?></span>
-					</span>
+					<span class="card-date"><?php echo esc_html( date( $atts['date_format'], strtotime( $content->date ) ) ); ?></span>
 					<div class="card-excerpt">
 						<?php echo wp_kses_post( $content->excerpt ); ?>
 					</div>

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -175,9 +175,9 @@ function wsuwp_json_output( $content, $data, $atts ) {
 					<span class="card-byline">
 						<span class="card-date"><?php echo esc_html( date( $atts['date_format'], strtotime( $content->date ) ) ); ?></span>
 					</span>
-					<span class="card-excerpt">
+					<div class="card-excerpt">
 						<?php echo wp_kses_post( $content->excerpt ); ?>
-					</span>
+					</div>
 				</article>
 				<?php
 			}

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -150,6 +150,7 @@ function wsuwp_json_output( $content, $data, $atts ) {
 
 				?>
 				<article class="card card--news">
+					<?php if ( ! is_front_page() ) { ?>
 					<span class="card-categories">
 						<?php
 						$category_output = array();
@@ -161,6 +162,7 @@ function wsuwp_json_output( $content, $data, $atts ) {
 						echo $category_output; // @codingStandardsIgnoreLine
 						?>
 					</span>
+					<?php } ?>
 					<?php if ( ! empty( $content->thumbnail ) ) : ?>
 					<?php $image_url = get_image_url( $content, $atts ); ?>
 					<figure class="card-image">

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -2,6 +2,7 @@
 global $is_top_feature, $is_river;
 ?>
 <article class="card card--news">
+	<?php if ( false === $is_top_feature ) { ?>
 	<span class="card-categories"><?php
 	$category_html = '';
 	foreach ( get_the_category() as $category ) {
@@ -11,6 +12,7 @@ global $is_top_feature, $is_river;
 	$category_html = rtrim( $category_html, ',' );
 	echo $category_html; // @codingStandardsIgnoreLine
 	?></span>
+	<?php } ?>
 
 	<?php if ( spine_has_featured_image() && false === $is_river ) { ?>
 	<figure class="card-image">

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -27,7 +27,7 @@ global $is_top_feature, $is_river;
 	<span class="card-byline">
 		<span class="card-date"><?php echo get_the_date(); ?></span>
 	</span>
-	<span class="card-excerpt">
+	<div class="card-excerpt">
 		<?php the_excerpt(); ?>
-	</span>
+	</div>
 </article>

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -1,5 +1,5 @@
 <?php
-global $is_top_feature;
+global $is_top_feature, $is_river;
 ?>
 <article class="card card--news">
 	<span class="card-categories"><?php
@@ -12,7 +12,7 @@ global $is_top_feature;
 	echo $category_html; // @codingStandardsIgnoreLine
 	?></span>
 
-	<?php if ( spine_has_featured_image() ) { ?>
+	<?php if ( spine_has_featured_image() && false === $is_river ) { ?>
 	<figure class="card-image">
 		<a href="<?php the_permalink(); ?>"><?php if ( $is_top_feature ) { the_post_thumbnail( 'spine-large_size' ); } else { the_post_thumbnail( 'spine-small_size' ); } ?></a>
 	</figure>

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -2,7 +2,7 @@
 global $is_top_feature, $is_river;
 ?>
 <article class="card card--news">
-	<?php if ( false === $is_top_feature && ! is_category() ) { ?>
+	<?php if ( ! is_category() && is_front_page() ) { ?>
 	<span class="card-categories"><?php
 	$category_html = '';
 	foreach ( get_the_category() as $category ) {

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -2,7 +2,7 @@
 global $is_top_feature, $is_river;
 ?>
 <article class="card card--news">
-	<?php if ( false === $is_top_feature ) { ?>
+	<?php if ( false === $is_top_feature && ! is_category() ) { ?>
 	<span class="card-categories"><?php
 	$category_html = '';
 	foreach ( get_the_category() as $category ) {

--- a/parts/card-content.php
+++ b/parts/card-content.php
@@ -24,9 +24,8 @@ global $is_top_feature, $is_river;
 		<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 	</header>
 
-	<span class="card-byline">
-		<span class="card-date"><?php echo get_the_date(); ?></span>
-	</span>
+	<span class="card-date"><?php echo get_the_date(); ?></span>
+
 	<div class="card-excerpt">
 		<?php the_excerpt(); ?>
 	</div>

--- a/style-guide/category.html
+++ b/style-guide/category.html
@@ -73,9 +73,7 @@
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/10/01/wsu-in-the-spotlight/">WSU in the spotlight</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">October 1, 2017</div>
-								</div>
+								<div class="card-date">October 1, 2017</div>
 								<div class="card-excerpt">
 									<p>Friday night&#8217;s 30-27 upset win over fifth-ranked USC thrust WSU into a national limelight that continued to shine throughout the weekend as the Cougars climbed to No. 11 on the latest Associated Press Top 25 poll. A sampling of reactions, from ESPN to the Washington Post, suggests others are discovering what Cougar Nation already knew has been building on the Palouse.</p>
 								</div>
@@ -87,68 +85,48 @@
 					<div class="column one">
 						<div class="deck">
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<figure class="card-image">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/"><img alt="Nursing student Mike Mosier at makeshift butcher table" class="attachment-spine-small_size size-spine-small_size wp-post-image" height="388" sizes="(max-width: 396px) 100vw, 396px" src="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg" srcset="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg 396w, https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering.jpg 594w" width="396"></a>
 								</figure>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<figure class="card-image">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/"><img alt="Nursing student Mike Mosier at makeshift butcher table" class="attachment-spine-small_size size-spine-small_size wp-post-image" height="388" sizes="(max-width: 396px) 100vw, 396px" src="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg" srcset="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg 396w, https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering.jpg 594w" width="396"></a>
 								</figure>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<figure class="card-image">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/"><img alt="Nursing student Mike Mosier at makeshift butcher table" class="attachment-spine-small_size size-spine-small_size wp-post-image" height="388" sizes="(max-width: 396px) 100vw, 396px" src="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg" srcset="https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering-396x388.jpg 396w, https://s3.wp.wsu.edu/uploads/sites/1753/2017/09/butchering.jpg 594w" width="396"></a>
 								</figure>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
@@ -163,85 +141,55 @@
 						</header>
 						<div class="deck deck--list">
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>
 							</article>
 							<article class="card card-news">
-								<div class="card-categories">
-									<a href="https://news.wsu.edu/insider/category/cheers/">Cheers</a>
-								</div>
 								<header class="card-title">
 									<a href="https://news.wsu.edu/insider/2017/09/29/nursing-student-pinch-hits-as-makeshift-butcher/">Nursing student pinch hits as makeshift butcher</a>
 								</header>
-								<div class="card-byline">
-									<div class="card-date">September 29, 2017</div>
-								</div>
+								<div class="card-date">September 29, 2017</div>
 								<div class="card-excerpt">
 									<p>The call went out to the day room at the Union Gospel Mission men’s shelter in Spokane: “Hey, we need somebody who can butcher up some animals.&#8221;</p>
 								</div>

--- a/style.css
+++ b/style.css
@@ -217,11 +217,6 @@ main figure > a {
 	margin-bottom: 1rem;
 }
 
-main .cat-sec .card-categories,
-.category main .card-categories {
-	display: none;
-}
-
 .card-title {
 	margin-bottom: .5rem;
 }
@@ -244,7 +239,6 @@ main .cat-sec .card-categories,
 
 .deck--featured .card:first-child .card-title,
 .deck--featured .card:first-child .card-categories,
-.deck--featured .card:first-child .card-byline,
 .deck--featured .card:first-child .card-excerpt {
 	display: block;
 	padding-right: 1rem;
@@ -267,7 +261,6 @@ main .deck--featured .card:first-child .card-title a:after {
 
 	.deck--featured .card:first-child .card-title,
 	.deck--featured .card:first-child .card-categories,
-	.deck--featured .card:first-child .card-byline,
 	.deck--featured .card:first-child .card-excerpt,
 	.deck--featured .card:first-child .card-image {
 		padding-right: 0;


### PR DESCRIPTION
* Remove all `card-categories` output for category archive and front page views.
* Use `div` for card excerpt content.
* Do not output images in a river deck.
* Move `card-date` out of the byline.
* Remove unused `card-byline` markup.