### PR TITLE
Fix wrap issue between the `header` and first item in `Good to know`

### DIFF
--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -357,6 +357,7 @@ main .deck--featured .card .card-title a:after {
 }
 
 .deck--numbered-list .deck-header {
+	display: block;
 	margin: 0 0 3rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -373,6 +373,7 @@ main .deck--featured .card .card-title a:after {
 }
 
 .deck--numbered-list .deck-header {
+	display: block;
 	margin: 0 0 3rem;
 }
 


### PR DESCRIPTION
- set `deck-header` to `display: block;` in `deck--numbered-list`  to prevent wrapping issues at around 700-800px. This is an issues when the first `card--news` has a short `card-title`.