### PR TITLE
[PR] Improve pagination on category archives

### DIFF
--- a/category.php
+++ b/category.php
@@ -102,16 +102,36 @@ $page = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 		}
 
 		$args = array(
-			'base'         => str_replace( 99164, '%#%', esc_url( get_pagenum_link( 99164 ) ) ),
-			'format'       => 'page/%#%',
-			'total'        => $archive_query->max_num_pages, // Provide the number of pages this query expects to fill.
-			'current'      => max( 1, get_query_var( 'paged' ) ), // Provide either 1 or the page number we're on.
+			'base'               => str_replace( 99164, '%#%', esc_url( get_pagenum_link( 99164 ) ) ),
+			'format'             => 'page/%#%',
+			'total'              => $archive_query->max_num_pages, // Provide the number of pages this query expects to fill.
+			'type'               => 'array',
+			'current'            => max( 1, get_query_var( 'paged' ) ), // Provide either 1 or the page number we're on.
+			'prev_text'          => 'Previous <span class="screen-reader-text">page</span>',
+			'next_text'          => 'Next <span class="screen-reader-text">page</span>',
+			'before_page_number' => '<span class="screen-reader-text">Page </span>',
 		);
 		?>
 		<footer class="main-footer archive-footer">
 			<section class="row side-right pager prevnext gutter">
 				<div class="column one">
-					<?php echo paginate_links( $args ); // @codingStandardsIgnoreLine ?>
+					<?php
+					$paginate_links = paginate_links( $args );
+
+					if ( ! empty( $paginate_links ) ) {
+						?>
+						<nav role="navigation" aria-label="Pagination navigation">
+							<ul>
+								<?php
+								foreach ( $paginate_links as $paginate_link ) {
+									echo '<li>' . $paginate_link . '</li>'; // @codingStandardsIgnoreLine
+								}
+								?>
+							</ul>
+						</nav>
+						<?php
+					}
+					?>
 				</div>
 				<div class="column two">
 					<!-- intentionally empty -->

--- a/category.php
+++ b/category.php
@@ -2,6 +2,8 @@
 
 get_header();
 global $is_top_feature, $is_river, $is_good_to_know;
+
+$page = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 ?>
 	<main id="wsuwp-main" class="spine-category-index">
 
@@ -19,7 +21,9 @@ global $is_top_feature, $is_river, $is_good_to_know;
 		$is_river = false;
 
 		$skip_post_id = array();
-		if ( have_posts() ) {
+
+		// Display the category's most recent featured story on the category's first page.
+		if ( have_posts() && 1 === $page ) {
 			?>
 			<section class="row single gutter pad-top news-features">
 
@@ -51,6 +55,7 @@ global $is_top_feature, $is_river, $is_good_to_know;
 			'posts_per_page' => 20, // Start with a high number until pagination.
 			'category_name' => get_query_var( 'category_name' ),
 			'post__not_in' => $skip_post_id,
+			'paged' => absint( $page ),
 		) );
 
 		if ( $archive_query->have_posts() ) {
@@ -96,14 +101,10 @@ global $is_top_feature, $is_river, $is_good_to_know;
 			<?php
 		}
 
-		/* @type WP_Query $wp_query */
-		global $wp_query;
-
-		$big = 99164;
 		$args = array(
-			'base'         => str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) ),
+			'base'         => str_replace( 99164, '%#%', esc_url( get_pagenum_link( 99164 ) ) ),
 			'format'       => 'page/%#%',
-			'total'        => $wp_query->max_num_pages, // Provide the number of pages this query expects to fill.
+			'total'        => $archive_query->max_num_pages, // Provide the number of pages this query expects to fill.
 			'current'      => max( 1, get_query_var( 'paged' ) ), // Provide either 1 or the page number we're on.
 		);
 		?>

--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -365,6 +365,11 @@ main .deck--featured .card .card-title a:after {
 	text-align: right;
 }
 
+.archive-footer nav li {
+	display: inline-block;
+	padding: 0 .2em;
+}
+
 @media screen and (max-width: 693px) {
 
 	#binder .row.news-features .column.multi-deck {

--- a/includes/featured-stories.php
+++ b/includes/featured-stories.php
@@ -16,15 +16,18 @@ function filter_query_for_featured_posts( $query ) {
 		return;
 	}
 
-	// The most recent featured story displays on the top of every paginated
-	// category archive page.
+	// Always short-circuit the main category query to look for one post.
 	$query->set( 'posts_per_page', 1 );
-	$query->set( 'meta_query', array(
-		array(
-			'key' => '_news_internal_featured',
-			'value' => 'yes',
-		),
-	) );
+
+	// A category's latest featured story displays only on the first page of that category archive.
+	if ( 0 === absint( get_query_var( 'paged', 0 ) ) ) {
+		$query->set( 'meta_query', array(
+			array(
+				'key' => '_news_internal_featured',
+				'value' => 'yes',
+			),
+		) );
+	}
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -380,6 +380,11 @@ main .deck--featured .card .card-title a:after {
 	text-align: right;
 }
 
+.archive-footer nav li {
+	display: inline-block;
+	padding: 0 .2em;
+}
+
 @media screen and (max-width: 693px) {
 
 	#binder .row.news-features .column.multi-deck {


### PR DESCRIPTION
* Base pagination on the secondary archive query rather than the hijacked main query that we use for features.
* Improve pagination HTML output to be more accessible using http://www.a11ymatters.com/pattern/pagination/ as a guide.