### PR TITLE
[PR] Enable announcements

### DIFF
--- a/css/00-banner.css
+++ b/css/00-banner.css
@@ -5,5 +5,5 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.11.5
+ Version:        0.12.0
 */

--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -664,14 +664,14 @@ main .bottom-divider {
 }
 
 /* --- custom TablePress styles --- */
-.tablepress tfoot th, 
+.tablepress tfoot th,
 .tablepress thead th {
 	background-color: #5d686f;
 	color: #fff;
 	font-weight: 400;
 }
 
-.tablepress tfoot th:hover, 
+.tablepress tfoot th:hover,
 .tablepress thead th:hover {
 	background-color: #43474a;
 }

--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -189,6 +189,7 @@ blockquote {
 }
 
 @media screen and (max-width: 659px) {
+
 	blockquote {
 		width: 100% !important;
 	}
@@ -196,30 +197,35 @@ blockquote {
 
 /* --- custom breakpoints for pullquotes or other items --- */
 @media screen and (max-width: 1300px) {
+
 	.full1300 {
 		width: 100% !important;
 	}
 }
 
 @media screen and (max-width: 1200px) {
+
 	.full1200 {
 		width: 100% !important;
 	}
 }
 
 @media screen and (max-width: 990px) {
+
 	.full990 {
 		width: 100% !important;
 	}
 }
 
 @media screen and (max-width: 660px) {
+
 	.full660 {
 		width: 100% !important;
 	}
 }
 
 @media screen and (max-width: 320px) {
+
 	.full320 {
 		width: 100% !important;
 	}
@@ -660,12 +666,12 @@ main .bottom-divider {
 /* --- custom TablePress styles --- */
 .tablepress tfoot th, 
 .tablepress thead th {
-	background-color:#5d686f;
-	color:#fff;
-	font-weight:400;
+	background-color: #5d686f;
+	color: #fff;
+	font-weight: 400;
 }
 
 .tablepress tfoot th:hover, 
 .tablepress thead th:hover {
-	background-color:#43474a;
+	background-color: #43474a;
 }

--- a/front-page.php
+++ b/front-page.php
@@ -119,9 +119,10 @@ get_header();
 		}
 
 		$section_query = new WP_Query( array(
+			'post_type'      => array( 'post', 'wsu_announcement' ),
 			'posts_per_page' => (int) $front_section['count'],
-			'category_name' => $section_slug,
-			'post__not_in' => $skip_post_ids,
+			'category_name'  => $section_slug,
+			'post__not_in'   => $skip_post_ids,
 		) );
 
 		if ( $section_query->have_posts() ) {

--- a/functions.php
+++ b/functions.php
@@ -18,7 +18,7 @@ add_filter( 'spine_child_theme_version', 'internal_news_theme_version' );
  * @return string
  */
 function internal_news_theme_version() {
-	return '0.11.5';
+	return '0.12.0';
 }
 
 add_action( 'wp_enqueue_scripts', 'internal_news_enqueue_scripts' );

--- a/includes/announcements.php
+++ b/includes/announcements.php
@@ -58,7 +58,7 @@ function register_post_type() {
 		'has_archive'        => 'announcements',
 		'hierarchical'       => false,
 		'menu_position'      => 5,
-		'supports'           => array( 'title', 'editor' ),
+		'supports'           => array( 'title', 'editor', 'thumbnail' ),
 		'show_in_rest'       => true,
 		'rest_base'          => 'announcements',
 	);

--- a/includes/announcements.php
+++ b/includes/announcements.php
@@ -59,7 +59,7 @@ function register_post_type() {
 		'taxonomies'         => array( 'category' ),
 		'hierarchical'       => false,
 		'menu_position'      => 5,
-		'supports'           => array( 'title', 'editor', 'thumbnail' ),
+		'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
 		'show_in_rest'       => true,
 		'rest_base'          => 'announcements',
 	);

--- a/includes/announcements.php
+++ b/includes/announcements.php
@@ -56,6 +56,7 @@ function register_post_type() {
 		),
 		'capability_type'    => 'post',
 		'has_archive'        => 'announcements',
+		'taxonomies'         => array( 'category' ),
 		'hierarchical'       => false,
 		'menu_position'      => 5,
 		'supports'           => array( 'title', 'editor', 'thumbnail' ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "news.wsu.edu-internal",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "news.wsu.edu-internal",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/news.wsu.edu-internal"

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.11.5
+ Version:        0.12.0
 */
 
 html {


### PR DESCRIPTION
The news.wsu.edu theme has options in the customizer to build out sections on the homepage. Currently these sections only support the post post_type. The purpose of this update is to allow the custom post_type announcements to feed into these sections as well.

## Updated
- Added feature image support to wsu_announcement post_type,
- Added excerpt support to wsu_announcement post_type,
- Added post_type wsu_announcement to WP_Query so it will be included in the results,
- Added category taxonomy to wsu_announcements.