### PR TITLE
[PR] Add announcment post type to category archive

### DIFF
--- a/includes/announcements.php
+++ b/includes/announcements.php
@@ -459,7 +459,7 @@ function filter_archive_query( $wp_query ) {
 		$wp_query->set( 'posts_per_page', '-1' );
 	} elseif ( $wp_query->is_post_type_archive( get_post_type_slug() ) && $wp_query->is_date() && $wp_query->is_main_query() ) {
 		$wp_query->set( 'posts_per_page', '-1' );
-	} elseif ( ! is_admin() && $wp_query->is_main_query() && is_category() ) {
+	} elseif ( $wp_query->is_main_query() && is_category() ) {
 		$wp_query->set( 'post_type', array( 'post', 'wsu_announcement' ) );
 	}
 }

--- a/includes/announcements.php
+++ b/includes/announcements.php
@@ -459,6 +459,8 @@ function filter_archive_query( $wp_query ) {
 		$wp_query->set( 'posts_per_page', '-1' );
 	} elseif ( $wp_query->is_post_type_archive( get_post_type_slug() ) && $wp_query->is_date() && $wp_query->is_main_query() ) {
 		$wp_query->set( 'posts_per_page', '-1' );
+	} elseif ( ! is_admin() && $wp_query->is_main_query() && is_category() ) {
+		$wp_query->set( 'post_type', array( 'post', 'wsu_announcement' ) );
 	}
 }
 


### PR DESCRIPTION
## Added
-  Add announcement post type to pre_get_posts action on category archive pages | closes #158 .